### PR TITLE
Don't generate a source jar.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -78,17 +78,6 @@
         </pluginManagement>
         <plugins>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-source-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>jar</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
                 <groupId>org.apache.rat</groupId>
                 <artifactId>apache-rat-plugin</artifactId>
                 <version>0.9</version>


### PR DESCRIPTION
This is a handy tool. Currently, the install instructions using `mvn clean package` generates two jars:

 - jsonpps-1.2-SNAPSHOT.jar
 - jsonpps-1.2-SNAPSHOT-sources.jar

The launcher shell script then gets confused as to which it should run when doing `JSONPPS_JAR="$( echo "${JSONPPS_DIR}"/target/jsonpps-*.jar )"`, resulting in an error:

```
Error: Unable to access jarfile /apps/jsonpps/target/jsonpps-1.2-SNAPSHOT.jar /apps/jsonpps/target/jsonpps-1.2-SNAPSHOT-sources.jar
```

I thought just removing source jar generation was the easiest fix, but an alternative approach would be to add a suffix to the generated code jar to make things unambiguous.